### PR TITLE
Remove trailing colon for CentOS7 when getting nic information from ifconfig

### DIFF
--- a/client/perl/nVentory/HardwareInfo.pm
+++ b/client/perl/nVentory/HardwareInfo.pm
@@ -1143,6 +1143,7 @@ sub getnicdata
 		my $nic;
 
 		my $os = nVentory::OSInfo::getos();
+		my $osversion = nVentory::OSInfo::getosversion();
 		
 		# get listening network ports (udp&tcp) PS-531
 		my %ports;
@@ -1178,7 +1179,7 @@ sub getnicdata
 				# mix up eth0.100 and eth0.100: (where the later is
 				# probably eth0.100:0 but got cut off by ifconfig)
 				if ($os eq 'FreeBSD' || $os eq 'SunOS' ||
-					$os eq 'Darwin' || $os eq 'Mac OS X')
+					$os eq 'Darwin' || $os eq 'Mac OS X' || ($os eq 'Red Hat CentOS Linux' && $osversion ge '7'))
 				{
 					$nic =~ s/:$//;
 				}

--- a/client/perl/nVentory/OSInfo.pm
+++ b/client/perl/nVentory/OSInfo.pm
@@ -549,7 +549,7 @@ sub getos
 					$os = "Red Hat $1 Linux";
 					$osversion = $2;
 				}
-				elsif ($rr =~ /(CentOS) release ([\d\.]+)/)
+				elsif ($rr =~ /(CentOS)(?: Linux | )release ([\d\.]+)/)
 				{
 					# Expand the OS name to include some extra terms
 					# that will make pattern matching for Linux or Red


### PR DESCRIPTION
CentOS7 added a trailing colon after each nic name. This made getnicdata report inconsistently for CentOS7. This change will correct that.
